### PR TITLE
Revert "schedutil_ts: enforce realtime priority" - slow down

### DIFF
--- a/kernel/sched/cpufreq_ts_schedutil.c
+++ b/kernel/sched/cpufreq_ts_schedutil.c
@@ -1036,7 +1036,7 @@ static void sugov_policy_free(struct sugov_policy *sg_policy)
 static int sugov_kthread_create(struct sugov_policy *sg_policy)
 {
 	struct task_struct *thread;
-	struct sched_param param = { .sched_priority = MAX_USER_RT_PRIO - 1 };
+	struct sched_param param = { .sched_priority = MAX_USER_RT_PRIO / 2 };
 	struct cpufreq_policy *policy = sg_policy->policy;
 	int ret;
 


### PR DESCRIPTION
This reverts commit 49ac95331209cf198516be3c9e1870e039e01b8e.